### PR TITLE
Reduce warnings with C++17

### DIFF
--- a/src/sMQTTMessage.h
+++ b/src/sMQTTMessage.h
@@ -4,6 +4,12 @@
 #include<vector>
 #include<string>
 
+#if (__cplusplus >= 201703L)
+#define MAYBE_UNUSED [[maybe_unused]]
+#else
+#define MAYBE_UNUSED
+#endif
+
 enum sMQTTError
 {
 	sMQTTOk = 0,
@@ -11,7 +17,7 @@ enum sMQTTError
 	sMQTTInvalidMessage = 2,
 };
 
-[[maybe_unused]] static const char *debugMessageType[] = {
+MAYBE_UNUSED static const char *debugMessageType[] = {
 	"Unknown",
 	"Connect",
 	"ConnAck",

--- a/src/sMQTTMessage.h
+++ b/src/sMQTTMessage.h
@@ -11,7 +11,7 @@ enum sMQTTError
 	sMQTTInvalidMessage = 2,
 };
 
-static const char *debugMessageType[] = {
+[[maybe_unused]] static const char *debugMessageType[] = {
 	"Unknown",
 	"Connect",
 	"ConnAck",

--- a/src/sMQTTTopic.h
+++ b/src/sMQTTTopic.h
@@ -36,7 +36,7 @@ public:
 	const char *Payload() {
 		return _payload;
 	}
-	const unsigned char QoS() {
+	unsigned char QoS() {
 		return qos;
 	}
 	bool match(sMQTTTopic *other);

--- a/src/sMQTTplatform.h
+++ b/src/sMQTTplatform.h
@@ -3,6 +3,12 @@
 
 #define SMQTT_DEPRECATED(msg) [[deprecated(msg)]]
 
+#if (__cplusplus >= 201703L)
+#define MAYBE_UNUSED [[maybe_unused]]
+#else
+#define MAYBE_UNUSED
+#endif
+
 #if defined(SMQTT_USER_SOCKET)
 // create and write your client and server
 #include"smqtt_user_socket.h"
@@ -39,7 +45,7 @@ public:
 #endif
 #define TCPClient WiFiClient
 #define TCPServer WiFiServer
-[[maybe_unused]] static const char *SMQTTTAG = "sMQTTBroker";
+MAYBE_UNUSED static const char *SMQTTTAG = "sMQTTBroker";
 #define SMQTT_LOGD(...) ESP_LOGD(SMQTTTAG,__VA_ARGS__)
 #elif defined(WIO_TERMINAL)
 #include <rpcWiFi.h>

--- a/src/sMQTTplatform.h
+++ b/src/sMQTTplatform.h
@@ -39,7 +39,7 @@ public:
 #endif
 #define TCPClient WiFiClient
 #define TCPServer WiFiServer
-static const char *SMQTTTAG = "sMQTTBroker";
+[[maybe_unused]] static const char *SMQTTTAG = "sMQTTBroker";
 #define SMQTT_LOGD(...) ESP_LOGD(SMQTTTAG,__VA_ARGS__)
 #elif defined(WIO_TERMINAL)
 #include <rpcWiFi.h>


### PR DESCRIPTION
This PR reduces the warnings emitted by compiler C++17 and better.
This is important because I aim to compile myproject with -Wall -Wextra but platformio does not allow setting up different flags for libraries to selectively ignore warnings not in my code.
This covers some of the points raised in PR #24 

The depreciation warnings remains because I did not find a good way to remove them considering the deprecated functions are used internally to the library, and can't be made private without some refactoring.

