### PR TITLE
Bugfix: buffer not increased by correct length

### DIFF
--- a/src/sMQTTMessage.h
+++ b/src/sMQTTMessage.h
@@ -75,7 +75,7 @@ public:
 	{
 		if (addLength)
 		{
-			buffer.reserve(buffer.size() + addLength + 2);
+			buffer.reserve(buffer.size() + len + 2);
 			incoming(len >> 8);
 			incoming(len & 0xFF);
 		}


### PR DESCRIPTION
It's actually only minor performance issue because vector will get extended anyways as needed.