### PR TITLE
Format strings bugfix

### DIFF
--- a/src/sMQTTBroker.cpp
+++ b/src/sMQTTBroker.cpp
@@ -232,7 +232,7 @@ bool sMQTTBroker::isClientConnected(sMQTTClient *client)
 			return false;
 		if (c->getClientId() == client->getClientId())
 		{
-			SMQTT_LOGD("found:%s client size:%d", client->getClientId(), clients.size());
+			SMQTT_LOGD("found:%s client size:%d", client->getClientId().c_str(), clients.size());
 			return true;
 		}
 	}

--- a/src/sMQTTClient.cpp
+++ b/src/sMQTTClient.cpp
@@ -29,7 +29,7 @@ void sMQTTClient::update()
 #endif
 	if (keepAlive != 0 && aliveMillis < currentMillis)
 	{
-		SMQTT_LOGD("aliveMillis(%d) < currentMillis(%d)", aliveMillis, currentMillis);
+		SMQTT_LOGD("aliveMillis(%lu) < currentMillis(%lu)", aliveMillis, currentMillis);
 		_client.stop();
 	}
 	//else


### PR DESCRIPTION
Fixing the following warnings:

SMQTT_LOGD("aliveMillis(%d) < currentMillis(%d)", aliveMillis, currentMillis);

format '%d' expects argument of type 'int', but argument 6 has type 'long unsigned int' [-Wformat=]

SMQTT_LOGD("found:%s client size:%d", client->getClientId(), clients.size());

format '%s' expects argument of type 'char*', but argument 6 has type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} [-Wformat=]